### PR TITLE
[WIP] Gate import of typing_extensions

### DIFF
--- a/beartype_test/a00_unit/a00_typing/test_typing.py
+++ b/beartype_test/a00_unit/a00_typing/test_typing.py
@@ -25,18 +25,14 @@ def test_api_typing() -> None:
     # Defer heavyweight imports.
     import typing as official_typing
     from beartype import typing as beartype_typing
+    from beartype.typing._typingpep544 import _import_typing_extensions
     from beartype._util.py.utilpyversion import (
         IS_PYTHON_3_7,
         IS_PYTHON_AT_LEAST_3_8,
         IS_PYTHON_AT_LEAST_3_9,
     )
 
-    try:
-        import typing_extensions
-    except ImportError:
-        _HAZ_TYPING_EXTENSIONS = False
-    else:
-        _HAZ_TYPING_EXTENSIONS = True
+    _typing_extensions = _import_typing_extensions()
 
     # Frozen set of the basenames of all erroneously publicized public
     # attributes of all "typing" modules across all Python versions. Ideally,
@@ -116,11 +112,11 @@ def test_api_typing() -> None:
         # Else, this attribute is public and thus unignorable.
     }
 
-    if IS_PYTHON_3_7 and _HAZ_TYPING_EXTENSIONS:
+    if IS_PYTHON_3_7 and _typing_extensions:
         # Not really "official", but we'll fake it
         official_typing_attr_name_to_value.update({
             extension_typing_attr_name: getattr(
-                typing_extensions, extension_typing_attr_name)
+                _typing_extensions, extension_typing_attr_name)
             for extension_typing_attr_name in (
                 'Protocol',
                 'SupportsIndex',
@@ -143,7 +139,7 @@ def test_api_typing() -> None:
     # submodule.
     TYPING_ATTR_UNEQUAL_NAMES = set()
 
-    if IS_PYTHON_AT_LEAST_3_8 or IS_PYTHON_3_7 and _HAZ_TYPING_EXTENSIONS:
+    if IS_PYTHON_AT_LEAST_3_8 or IS_PYTHON_3_7 and _typing_extensions:
         TYPING_ATTR_UNEQUAL_NAMES.update({
             'Protocol',
             'SupportsAbs',

--- a/tox.ini
+++ b/tox.ini
@@ -91,7 +91,7 @@
 # For example, setting "envlist = py27,py38" produces a test matrix exercising
 # the externally installed "python2.7" and "python3.8" commands. See also:
 #     https://tox.readthedocs.io/en/latest/config.html#generating-environments-conditional-settings
-envlist = py{36,37,38,39,310,311,py36,py37,py38}-coverage
+envlist = py{36,37,38,39,310,311,py36,py37,py38}-coverage,py{37,py37}-coverage-notypext
 
 #FIXME: Override this from within CI configurations by passing the
 #"--skip-missing-interpreters=false" when running the "tox" command,
@@ -174,6 +174,8 @@ setenv =
     # which lacks sufficient configurability and friendly maintainership to
     # warrant yet another fragile dependency.
     coverage: _COVERAGE_COMMAND = coverage run -m
+
+    {py37,pypy37}-notypext: _BEARTYPE_PY_3_7_EXCLUDE_TYPING_EXTENSIONS = 1
 
 # Newline-delimited string listing all environment variables to be passed from
 # the current shell process to each shell subprocess running tests.


### PR DESCRIPTION
PR #103 allows `beartype` to opportunistically leverage `typing_extensions` to back-port its caching protocol implementation when running in 3.7. `typing_extensions` is swept into beartypes testing environments via other dependencies (including `pytest`). This makes testing difficult regarding how beartype will behave when running in 3.7 where `typing_extensions` is *not* present. This PR provides a mechanism to gate importing of `typing_extensions` in order to properly validate that environment.

Depends on #103.